### PR TITLE
Restyle Image-GS portfolio interface

### DIFF
--- a/src/index.css
+++ b/src/index.css
@@ -3,7 +3,7 @@
 @tailwind utilities;
 
 body {
-  @apply bg-slate-50 text-slate-900 antialiased;
+  @apply bg-slate-950 text-slate-100 antialiased;
 }
 
 #root {


### PR DESCRIPTION
## Summary
- redesign the Image-GS UI with a gradient hero, portfolio-ready copy, and status badge styling
- reorganize workflow controls, tuning inputs, and metrics into glassmorphism-inspired cards with upgraded inputs and buttons
- refresh the live preview layout, add a tip callout, and switch the global theme to a dark background for better contrast

## Testing
- npm run build
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68c901479258832c98fcbe21d040cb6a