### PR TITLE
Refine training UI and modularize engine

### DIFF
--- a/src/components/InfoPopover.jsx
+++ b/src/components/InfoPopover.jsx
@@ -1,0 +1,52 @@
+import { useEffect, useId, useRef, useState } from 'react'
+
+export default function InfoPopover({ title, description }) {
+  const [open, setOpen] = useState(false)
+  const containerRef = useRef(null)
+  const tooltipId = useId()
+
+  useEffect(() => {
+    if (!open) return
+    const handleClick = (event) => {
+      if (containerRef.current && !containerRef.current.contains(event.target)) {
+        setOpen(false)
+      }
+    }
+    const handleKey = (event) => {
+      if (event.key === 'Escape') setOpen(false)
+    }
+    document.addEventListener('mousedown', handleClick)
+    document.addEventListener('keydown', handleKey)
+    return () => {
+      document.removeEventListener('mousedown', handleClick)
+      document.removeEventListener('keydown', handleKey)
+    }
+  }, [open])
+
+  return (
+    <div ref={containerRef} className="relative inline-flex">
+      <button
+        type="button"
+        aria-label={`More info about ${title}`}
+        aria-haspopup="dialog"
+        aria-expanded={open}
+        aria-controls={open ? tooltipId : undefined}
+        onClick={() => setOpen((prev) => !prev)}
+        className="inline-flex h-5 w-5 items-center justify-center rounded-full border border-white/20 bg-white/10 text-[10px] font-semibold text-slate-200 transition hover:border-sky-400 hover:text-sky-200 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-sky-400 focus-visible:ring-offset-1 focus-visible:ring-offset-slate-950"
+      >
+        i
+      </button>
+      {open && (
+        <div
+          role="dialog"
+          id={tooltipId}
+          aria-modal="false"
+          className="absolute right-0 top-full z-40 mt-2 w-64 rounded-2xl border border-white/10 bg-slate-950/95 p-4 text-left shadow-xl shadow-slate-950/60"
+        >
+          <p className="text-sm font-semibold text-white">{title}</p>
+          <p className="mt-2 text-xs leading-relaxed text-slate-300">{description}</p>
+        </div>
+      )}
+    </div>
+  )
+}

--- a/src/lib/gaussianMath.js
+++ b/src/lib/gaussianMath.js
@@ -1,0 +1,97 @@
+export const EPS = 1e-6
+
+export const clamp = (x, lo, hi) => Math.min(Math.max(x, lo), hi)
+
+export function sobelMagJS(rgb, w, h) {
+  const mag = new Float32Array(w * h)
+  const kx = [-1, 0, 1, -2, 0, 2, -1, 0, 1]
+  const ky = [-1, -2, -1, 0, 0, 0, 1, 2, 1]
+  for (let y = 0; y < h; y++) {
+    for (let x = 0; x < w; x++) {
+      let gx = 0
+      let gy = 0
+      for (let dy = -1; dy <= 1; dy++)
+        for (let dx = -1; dx <= 1; dx++) {
+          const xx = clamp(x + dx, 0, w - 1)
+          const yy = clamp(y + dy, 0, h - 1)
+          const i = yy * w + xx
+          const r = rgb[i * 3 + 0]
+          const g = rgb[i * 3 + 1]
+          const b = rgb[i * 3 + 2]
+          const gray = 0.299 * r + 0.587 * g + 0.114 * b
+          const kIdx = (dy + 1) * 3 + (dx + 1)
+          gx += gray * kx[kIdx]
+          gy += gray * ky[kIdx]
+        }
+      mag[y * w + x] = Math.sqrt(gx * gx + gy * gy)
+    }
+  }
+  return mag
+}
+
+export function cpuTopKIndices(arr, K) {
+  const n = arr.length
+  const k = Math.min(K, n)
+  const idxs = new Array(k).fill(-1)
+  const vals = new Array(k).fill(-Infinity)
+  for (let i = 0; i < n; i++) {
+    const v = arr[i]
+    if (v > vals[k - 1]) {
+      let j = k - 1
+      while (j > 0 && v > vals[j - 1]) {
+        vals[j] = vals[j - 1]
+        idxs[j] = idxs[j - 1]
+        j--
+      }
+      vals[j] = v
+      idxs[j] = i
+    }
+  }
+  return idxs
+}
+
+export function samplePositionsAndColorsJS(imgF32, w, h, prob2D, N) {
+  const prob = new Float32Array(prob2D)
+  let s = 0
+  for (let i = 0; i < prob.length; i++) s += prob[i]
+  s = s || 1
+  for (let i = 0; i < prob.length; i++) prob[i] /= s
+  const cdf = new Float32Array(prob.length)
+  let acc = 0
+  for (let i = 0; i < prob.length; i++) {
+    acc += prob[i]
+    cdf[i] = acc
+  }
+  const mu = new Float32Array(N * 2)
+  const colors = new Float32Array(N * 3)
+  for (let k = 0; k < N; k++) {
+    const r = Math.random()
+    let lo = 0
+    let hi = cdf.length - 1
+    while (lo < hi) {
+      const mid = (lo + hi) >> 1
+      if (cdf[mid] < r) lo = mid + 1
+      else hi = mid
+    }
+    const y = Math.floor(lo / w)
+    const x = lo % w
+    const idx = y * w + x
+    mu[k * 2 + 0] = x / (w - 1)
+    mu[k * 2 + 1] = y / (h - 1)
+    colors[k * 3 + 0] = imgF32[idx * 3 + 0]
+    colors[k * 3 + 1] = imgF32[idx * 3 + 1]
+    colors[k * 3 + 2] = imgF32[idx * 3 + 2]
+  }
+  return { mu, colors }
+}
+
+export function psnrJS(a, b) {
+  let mse = 0
+  for (let i = 0; i < a.length; i++) {
+    const d = a[i] - b[i]
+    mse += d * d
+  }
+  mse /= a.length || 1
+  if (mse <= 0) return Infinity
+  return 10 * Math.log10(1 / (mse + EPS))
+}

--- a/src/lib/imageLoader.js
+++ b/src/lib/imageLoader.js
@@ -1,0 +1,58 @@
+export function sourceToF32RGB(src, targetMax = 512) {
+  const c = document.createElement('canvas')
+  const w0 = Math.max(1, src.width)
+  const h0 = Math.max(1, src.height)
+  const scale = Math.min(1, targetMax / Math.max(w0, h0))
+  const w = Math.max(1, Math.round(w0 * scale))
+  const h = Math.max(1, Math.round(h0 * scale))
+  c.width = w
+  c.height = h
+  const ctx = c.getContext('2d', { willReadFrequently: true })
+  if (!ctx) throw new Error('Canvas 2D context unavailable')
+  try {
+    ctx.drawImage(src, 0, 0, w, h)
+  } catch (err) {
+    console.error('Rasterization failed (drawImage)', err)
+    throw new Error('Rasterization failed (drawImage). The file may be corrupt or blocked.')
+  }
+  let imgData
+  try {
+    imgData = ctx.getImageData(0, 0, w, h)
+  } catch (err) {
+    console.error('Reading pixels failed (getImageData)', err)
+    throw new Error('Reading pixels failed (getImageData). If this is an SVG with external refs, re-export as PNG/JPG.')
+  }
+  const data = imgData.data
+  const f32 = new Float32Array(w * h * 3)
+  for (let i = 0; i < w * h; i++) {
+    f32[i * 3 + 0] = data[i * 4 + 0] / 255
+    f32[i * 3 + 1] = data[i * 4 + 1] / 255
+    f32[i * 3 + 2] = data[i * 4 + 2] / 255
+  }
+  return { data: f32, w, h }
+}
+
+export async function fileToImageSource(file) {
+  if ('createImageBitmap' in window && typeof createImageBitmap === 'function') {
+    try {
+      const bmp = await createImageBitmap(file)
+      return { src: bmp, revoke: () => bmp.close?.() }
+    } catch (err) {
+      console.warn('createImageBitmap failed; falling back to HTMLImageElement', err)
+    }
+  }
+  const dataUrl = await new Promise((resolve, reject) => {
+    const fr = new FileReader()
+    fr.onerror = () => reject(new Error('FileReader failed'))
+    fr.onload = () => resolve(String(fr.result))
+    fr.readAsDataURL(file)
+  })
+  const img = await new Promise((resolve, reject) => {
+    const im = new Image()
+    im.crossOrigin = 'anonymous'
+    im.onload = () => resolve(im)
+    im.onerror = () => reject(new Error('Image decode failed'))
+    im.src = dataUrl
+  })
+  return { src: img, revoke: () => {} }
+}

--- a/src/lib/quantization.js
+++ b/src/lib/quantization.js
@@ -1,0 +1,20 @@
+export function float16Quantize(x) {
+  const f32 = x instanceof Float32Array ? x : new Float32Array(x)
+  const buf = new ArrayBuffer(f32.length * 2)
+  const dv = new DataView(buf)
+  for (let i = 0; i < f32.length; i++) dv.setUint16(i * 2, float32ToFloat16(f32[i]), true)
+  return new Uint8Array(buf)
+}
+
+export function float32ToFloat16(val) {
+  const f32 = new Float32Array(1)
+  const i32 = new Int32Array(f32.buffer)
+  f32[0] = val
+  const x = i32[0]
+  const bits = (x >> 16) & 0x8000
+  const m = (x >> 12) & 0x07ff
+  const e = (x >> 23) & 0xff
+  if (e < 103) return bits
+  if (e > 142) return bits | 0x7c00
+  return bits | ((e - 112) << 10) | (m >> 1)
+}

--- a/src/lib/training.js
+++ b/src/lib/training.js
@@ -1,0 +1,183 @@
+import { clamp, cpuTopKIndices, sobelMagJS, samplePositionsAndColorsJS } from './gaussianMath'
+
+export function initializeParameters(image, budget, lambdaInit) {
+  const { w, h, data } = image
+  const grad = sobelMagJS(data, w, h)
+  let sum = 0
+  for (let i = 0; i < grad.length; i++) sum += grad[i]
+  const uniform = 1 / (w * h)
+  const probs = new Float32Array(w * h)
+  for (let i = 0; i < w * h; i++) probs[i] = (1 - lambdaInit) * (grad[i] / (sum || 1)) + lambdaInit * uniform
+
+  const Ng0 = Math.max(1, Math.floor(budget / 2))
+  const { mu, colors } = samplePositionsAndColorsJS(data, w, h, probs, Ng0)
+  const s_inv = new Float32Array(Ng0 * 2)
+  for (let i = 0; i < Ng0; i++) {
+    s_inv[i * 2 + 0] = (w - 1) / 5
+    s_inv[i * 2 + 1] = (h - 1) / 5
+  }
+  const theta = new Float32Array(Ng0)
+  for (let i = 0; i < Ng0; i++) theta[i] = Math.random() * Math.PI
+
+  return { vars: { mu, s_inv, theta, color: colors }, count: Ng0 }
+}
+
+export function mergeAccumulators(parts, N) {
+  const accW = new Float32Array(N)
+  const accTW = new Float32Array(N * 3)
+  const accX = new Float32Array(N)
+  const accY = new Float32Array(N)
+  const accXX = new Float32Array(N)
+  const accYY = new Float32Array(N)
+  const accXY = new Float32Array(N)
+  for (const p of parts) {
+    const aW = p.accW
+    const aT = p.accTW
+    const aX = p.accX
+    const aY = p.accY
+    const aXX = p.accXX
+    const aYY = p.accYY
+    const aXY = p.accXY
+    for (let i = 0; i < N; i++) accW[i] += aW[i]
+    for (let i = 0; i < N * 3; i++) accTW[i] += aT[i]
+    for (let i = 0; i < N; i++) {
+      accX[i] += aX[i]
+      accY[i] += aY[i]
+      accXX[i] += aXX[i]
+      accYY[i] += aYY[i]
+      accXY[i] += aXY[i]
+    }
+  }
+  return { accW, accTW, accX, accY, accXX, accYY, accXY }
+}
+
+export function composeOutput(parts, W, H) {
+  const out = new Float32Array(W * H * 3)
+  for (const p of parts) {
+    if (!p.out) continue
+    const y0 = p.y0
+    const stripe = p.out
+    out.set(stripe, y0 * W * 3)
+  }
+  return out
+}
+
+export function updateParametersFromAccumulators(vars, accumulators, config) {
+  if (!vars) return
+  const { lrColor, lrMu, lrShape, size } = config
+  const { w, h } = size
+  const N = vars.mu.length / 2
+  for (let i = 0; i < N; i++) {
+    const wsum = accumulators.accW[i] + 1e-6
+    const tR = accumulators.accTW[i * 3 + 0] / wsum
+    const tG = accumulators.accTW[i * 3 + 1] / wsum
+    const tB = accumulators.accTW[i * 3 + 2] / wsum
+    vars.color[i * 3 + 0] = (1 - lrColor) * vars.color[i * 3 + 0] + lrColor * tR
+    vars.color[i * 3 + 1] = (1 - lrColor) * vars.color[i * 3 + 1] + lrColor * tG
+    vars.color[i * 3 + 2] = (1 - lrColor) * vars.color[i * 3 + 2] + lrColor * tB
+  }
+  const stdMinX = 1 / Math.max(w - 1, 1)
+  const stdMinY = 1 / Math.max(h - 1, 1)
+  for (let i = 0; i < N; i++) {
+    const wsum = accumulators.accW[i]
+    if (wsum < 1e-6) continue
+    const mx = accumulators.accX[i] / wsum
+    const my = accumulators.accY[i] / wsum
+    const muX = vars.mu[i * 2 + 0]
+    const muY = vars.mu[i * 2 + 1]
+    vars.mu[i * 2 + 0] = (1 - lrMu) * muX + lrMu * mx
+    vars.mu[i * 2 + 1] = (1 - lrMu) * muY + lrMu * my
+    const cxx = Math.max(0, accumulators.accXX[i] / wsum - mx * mx)
+    const cyy = Math.max(0, accumulators.accYY[i] / wsum - my * my)
+    const cxy = accumulators.accXY[i] / wsum - mx * my
+    const tr = cxx + cyy
+    const det = cxx * cyy - cxy * cxy
+    const disc = Math.max(0, tr * tr - 4 * det)
+    const s = Math.sqrt(disc)
+    const l1 = 0.5 * (tr + s)
+    const l2 = 0.5 * (tr - s)
+    let vx
+    let vy
+    if (Math.abs(cxy) > 1e-12) {
+      vx = l1 - cyy
+      vy = cxy
+    } else if (cxx >= cyy) {
+      vx = 1
+      vy = 0
+    } else {
+      vx = 0
+      vy = 1
+    }
+    const n = Math.hypot(vx, vy) || 1
+    vx /= n
+    vy /= n
+    let th0 = vars.theta[i] % Math.PI
+    if (th0 < 0) th0 += Math.PI
+    let thT = Math.atan2(vy, vx)
+    thT %= Math.PI
+    if (thT < 0) thT += Math.PI
+    if (Math.abs(thT - th0) > Math.PI / 2) {
+      if (thT > th0) thT -= Math.PI
+      else thT += Math.PI
+    }
+    const thNew = th0 + (thT - th0) * lrShape
+    vars.theta[i] = ((thNew % Math.PI) + Math.PI) % Math.PI
+    const std1 = Math.sqrt(Math.max(l1, 0))
+    const std2 = Math.sqrt(Math.max(l2, 0))
+    const sxInvTarget = 1 / Math.max(std1, Math.min(stdMinX, stdMinY))
+    const syInvTarget = 1 / Math.max(std2, Math.min(stdMinX, stdMinY))
+    const sx0 = vars.s_inv[i * 2 + 0]
+    const sy0 = vars.s_inv[i * 2 + 1]
+    vars.s_inv[i * 2 + 0] = clamp((1 - lrShape) * sx0 + lrShape * sxInvTarget, 0.1, (w - 1) * 4)
+    vars.s_inv[i * 2 + 1] = clamp((1 - lrShape) * sy0 + lrShape * syInvTarget, 0.1, (h - 1) * 4)
+  }
+}
+
+export function computeErrorField(out, target, width, height) {
+  const err = new Float32Array(width * height)
+  for (let i = 0; i < width * height; i++) {
+    err[i] =
+      (Math.abs(out[i * 3 + 0] - target[i * 3 + 0]) +
+        Math.abs(out[i * 3 + 1] - target[i * 3 + 1]) +
+        Math.abs(out[i * 3 + 2] - target[i * 3 + 2])) /
+      3
+  }
+  return err
+}
+
+export function selectErrorIndices(errorField, count) {
+  return cpuTopKIndices(errorField, count)
+}
+
+export function extendModelWithErrors(vars, indices, image) {
+  const { data: tgt, w: W, h: H } = image
+  const NgOld = vars.mu.length / 2
+  const nNew = indices.length
+  const NgNew = NgOld + nNew
+  const mu2 = new Float32Array(NgNew * 2)
+  mu2.set(vars.mu)
+  const s2 = new Float32Array(NgNew * 2)
+  s2.set(vars.s_inv)
+  const th2 = new Float32Array(NgNew)
+  th2.set(vars.theta)
+  const c2 = new Float32Array(NgNew * 3)
+  c2.set(vars.color)
+
+  for (let j = 0; j < indices.length; j++) {
+    const id = indices[j]
+    const y = Math.floor(id / W)
+    const x = id % W
+    const base = y * W + x
+    const i = NgOld + j
+    mu2[i * 2 + 0] = x / (W - 1)
+    mu2[i * 2 + 1] = y / (H - 1)
+    s2[i * 2 + 0] = (W - 1) / 5
+    s2[i * 2 + 1] = (H - 1) / 5
+    th2[i] = Math.random() * Math.PI
+    c2[i * 3 + 0] = tgt[base * 3 + 0]
+    c2[i * 3 + 1] = tgt[base * 3 + 1]
+    c2[i * 3 + 2] = tgt[base * 3 + 2]
+  }
+
+  return { vars: { mu: mu2, s_inv: s2, theta: th2, color: c2 }, count: NgNew }
+}

--- a/src/lib/workerFactory.js
+++ b/src/lib/workerFactory.js
@@ -1,0 +1,184 @@
+export const WORKER_SRC = `
+  const EPS = 1e-6;
+  const clamp = (x, lo, hi) => Math.min(Math.max(x, lo), hi);
+  function buildTileBinsFromArrays(muA, sInvA, H, W, tileH, tileW) {
+    if (!muA || !sInvA) {
+      const tilesX = Math.ceil(W / tileW);
+      const tilesY = Math.ceil(H / tileH);
+      return { tilesX, tilesY, bins: Array.from({ length: tilesX * tilesY }, () => []) };
+    }
+    const tilesX = Math.ceil(W / tileW);
+    const tilesY = Math.ceil(H / tileH);
+    const bins = Array.from({ length: tilesX * tilesY }, () => []);
+    const N = muA.length / 2;
+    for (let i = 0; i < N; i++) {
+      const ux = muA[i * 2 + 0], uy = muA[i * 2 + 1];
+      const sxInv = sInvA[i * 2 + 0], syInv = sInvA[i * 2 + 1];
+      const cx = ux * (W - 1), cy = uy * (H - 1);
+      const rx = 3 * (1 / Math.max(sxInv, EPS)) * W;
+      const ry = 3 * (1 / Math.max(syInv, EPS)) * H;
+      const r = Math.max(rx, ry);
+      const x0 = Math.max(0, Math.floor((cx - r) / tileW));
+      const y0 = Math.max(0, Math.floor((cy - r) / tileH));
+      const x1 = Math.min(tilesX - 1, Math.floor((cx + r) / tileW));
+      const y1 = Math.min(tilesY - 1, Math.floor((cy + r) / tileH));
+      for (let ty = y0; ty <= y1; ty++) {
+        const row = ty * tilesX;
+        for (let tx = x0; tx <= x1; tx++) bins[row + tx].push(i);
+      }
+    }
+    return { tilesX, tilesY, bins };
+  }
+
+  let IMG = null;
+  let W = 0, H = 0;
+  let tileW = 32, tileH = 32;
+  let enableTiling = true;
+  let bins = null;
+
+  function computeStepStripe(mu, s_inv, theta, color, K, wantImage, doRebin, y0Stripe, y1Stripe, reqId) {
+    const N = mu.length / 2;
+    if (!IMG) throw new Error('Worker not initialized');
+    if (enableTiling && (doRebin || !bins)) bins = buildTileBinsFromArrays(mu, s_inv, H, W, tileH, tileW);
+
+    const out = wantImage ? new Float32Array((y1Stripe - y0Stripe + 1) * W * 3) : null;
+    const accW = new Float32Array(N);
+    const accTW = new Float32Array(N * 3);
+    const accX = new Float32Array(N);
+    const accY = new Float32Array(N);
+    const accXX = new Float32Array(N);
+    const accYY = new Float32Array(N);
+    const accXY = new Float32Array(N);
+
+    const tilesX = bins ? bins.tilesX : Math.ceil(W / tileW);
+    const tilesY = bins ? bins.tilesY : Math.ceil(H / tileH);
+
+    const ty0 = Math.max(0, Math.floor(y0Stripe / tileH));
+    const ty1 = Math.min(tilesY - 1, Math.floor(y1Stripe / tileH));
+
+    for (let ty = ty0; ty <= ty1; ty++) {
+      const xTiles = tilesX;
+      const y0 = Math.max(y0Stripe, ty * tileH);
+      const y1 = Math.min(y1Stripe + 1, (ty + 1) * tileH);
+      for (let tx = 0; tx < xTiles; tx++) {
+        const x0 = tx * tileW;
+        const x1 = Math.min(W, x0 + tileW);
+        const list = enableTiling && bins ? bins.bins[ty * tilesX + tx] : null;
+        for (let y = y0; y < y1; y++) {
+          for (let x = x0; x < x1; x++) {
+            const cx = x / (W - 1), cy = y / (H - 1);
+            const topIdx = [];
+            const topVal = [];
+            const scan = (i) => {
+              const dx = cx - mu[i * 2 + 0];
+              const dy = cy - mu[i * 2 + 1];
+              const th = theta[i];
+              const c = Math.cos(th), s = Math.sin(th);
+              const dxp = c * dx + s * dy;
+              const dyp = -s * dx + c * dy;
+              const sx = s_inv[i * 2 + 0], sy = s_inv[i * 2 + 1];
+              const z = (dxp * sx) * (dxp * sx) + (dyp * sy) * (dyp * sy);
+              const g = Math.exp(-0.5 * z);
+              if (topIdx.length < K) {
+                let j = topIdx.length;
+                topIdx.push(i);
+                topVal.push(g);
+                while (j > 0 && topVal[j] > topVal[j - 1]) {
+                  const ti = topIdx[j - 1];
+                  topIdx[j - 1] = topIdx[j];
+                  topIdx[j] = ti;
+                  const tv = topVal[j - 1];
+                  topVal[j - 1] = topVal[j];
+                  topVal[j] = tv;
+                  j--;
+                }
+              } else if (g > topVal[topVal.length - 1]) {
+                topIdx[topIdx.length - 1] = i;
+                topVal[topVal.length - 1] = g;
+                let j = topIdx.length - 1;
+                while (j > 0 && topVal[j] > topVal[j - 1]) {
+                  const ti = topIdx[j - 1];
+                  topIdx[j - 1] = topIdx[j];
+                  topIdx[j] = ti;
+                  const tv = topVal[j - 1];
+                  topVal[j - 1] = topVal[j];
+                  topVal[j] = tv;
+                  j--;
+                }
+              }
+            };
+            if (list && list.length) {
+              for (let ii = 0; ii < list.length; ii++) scan(list[ii]);
+            } else {
+              for (let i = 0; i < N; i++) scan(i);
+            }
+            let wsum = EPS;
+            for (let k = 0; k < topVal.length; k++) wsum += topVal[k];
+            const baseGlobal = (y * W + x) * 3;
+            let r = 0, g = 0, b = 0;
+            for (let k = 0; k < topIdx.length; k++) {
+              const wi = topVal[k] / wsum;
+              const gi = topIdx[k];
+              r += wi * color[gi * 3 + 0];
+              g += wi * color[gi * 3 + 1];
+              b += wi * color[gi * 3 + 2];
+              accW[gi] += wi;
+              accTW[gi * 3 + 0] += wi * IMG[baseGlobal + 0];
+              accTW[gi * 3 + 1] += wi * IMG[baseGlobal + 1];
+              accTW[gi * 3 + 2] += wi * IMG[baseGlobal + 2];
+              const cxn = cx, cyn = cy;
+              accX[gi] += wi * cxn;
+              accY[gi] += wi * cyn;
+              accXX[gi] += wi * cxn * cxn;
+              accYY[gi] += wi * cyn * cyn;
+              accXY[gi] += wi * cxn * cyn;
+            }
+            if (out) {
+              const row = y - y0Stripe;
+              const baseLocal = (row * W + x) * 3;
+              out[baseLocal + 0] = r;
+              out[baseLocal + 1] = g;
+              out[baseLocal + 2] = b;
+            }
+          }
+        }
+      }
+    }
+
+    const msg = { type: 'stepResult', reqId, accW, accTW, accX, accY, accXX, accYY, accXY, y0: y0Stripe, y1: y1Stripe };
+    const transfers = [accW.buffer, accTW.buffer, accX.buffer, accY.buffer, accXX.buffer, accYY.buffer, accXY.buffer];
+    if (out) {
+      msg.out = out;
+      transfers.push(out.buffer);
+    }
+    postMessage(msg, transfers);
+  }
+
+  onmessage = (ev) => {
+    const m = ev.data;
+    if (m.type === 'init') {
+      IMG = m.img;
+      W = m.W;
+      H = m.H;
+      tileW = m.tileW;
+      tileH = m.tileH;
+      enableTiling = !!m.enableTiling;
+      bins = null;
+      postMessage({ type: 'inited' });
+    } else if (m.type === 'step') {
+      computeStepStripe(m.mu, m.s_inv, m.theta, m.color, m.K, !!m.wantImage, !!m.doRebin, m.y0, m.y1, m.reqId);
+    } else if (m.type === 'setTiling') {
+      tileW = m.tileW;
+      tileH = m.tileH;
+      enableTiling = !!m.enableTiling;
+      bins = null;
+    }
+  };
+`
+
+export function makeWorker() {
+  const blob = new Blob([WORKER_SRC], { type: 'text/javascript' })
+  const url = URL.createObjectURL(blob)
+  const worker = new Worker(url, { type: 'classic' })
+  return { worker, url }
+}


### PR DESCRIPTION
## Summary
- extracted training utilities, worker construction, and media helpers into dedicated modules to simplify App.jsx
- refreshed the client-facing interface copy, added informational popovers for every adjustable parameter, and exposed the splat growth cadence control
- introduced a reusable InfoPopover component to deliver clickable descriptions for parameter inputs

## Testing
- npm run build
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68c981416fd8832cad9d4145d165ca43